### PR TITLE
update for stricter type version for redisparser

### DIFF
--- a/redisclient.nimble
+++ b/redisclient.nimble
@@ -1,14 +1,13 @@
 # Package
 
-version       = "0.1.2"
+version       = "0.2.0"
 author        = "xmonader"
 description   = "Redis client for Nim"
 license       = "Apache2"
 srcDir        = "src"
 
 # Dependencies
-requires "nim >= 0.18.0", "redisparser >= 0.1.2"
-
+requires "nim >= 0.18.0", "redisparser >= 0.2.0"
 
 
 task genDocs, "Create code documentation for redisclient":

--- a/src/redisclient/connpool.nim
+++ b/src/redisclient/connpool.nim
@@ -6,8 +6,6 @@ from net import Port
 ## https://github.com/zedeus/redpool
 
 type
-  ConnectionError* = object of IOError
-
   RedisConn[T: Redis|AsyncRedis] = ref object
     active: bool
     conn: T

--- a/tests/testredisclient.nim
+++ b/tests/testredisclient.nim
@@ -1,9 +1,9 @@
 
-import strformat, tables, json, strutils, sequtils, hashes, net, asyncdispatch, asyncnet, os, strutils, parseutils, deques, options
+import strutils, net, asyncdispatch
 
 import redisparser, redisclient
 
-proc testSync() = 
+proc testSync() =
   let con = open("localhost", 6379.Port)
   echo $con.execCommand("PING", @[])
 
@@ -38,7 +38,7 @@ proc testAsync() {.async.} =
   await con.enqueueCommand("PING", @[])
   await con.enqueueCommand("PING", @[])
   echo await con.commitCommands()
- 
+
 
 
 proc testHighlevelAPI() =

--- a/tests/testsortedsets.nim
+++ b/tests/testsortedsets.nim
@@ -1,0 +1,46 @@
+import redisclient, unittest
+
+proc `&&`(s: string): auto = newRedisBulkString(s)
+
+template syncTests() =
+  let r = redisclient.open("localhost")
+  let keys = r.keys("*")
+  doassert keys.len == 0, "Don't want to mess up an existing DB."
+
+  test "sorted sets":
+
+    discard r.zadd("redisTest:myzset", 1, "one")
+    discard r.zadd("redisTest:myzset", 2, "two")
+    discard r.zadd("redisTest:myzset", 3, "three")
+
+    check r.zcard("redisTest:myzset") == 3
+
+    check r.zcount("redisTest:myzset", "-inf", "+inf") == 3
+    check r.zcount("redisTest:myzset", "(1", "3") == 2
+
+    discard r.zadd("redisTest:myzset", 2, "four")
+    discard r.zincrby("redisTest:myzset", 2, "four")
+    check r.zscore("redisTest:myzset", "four") == &&"4"
+    check r.zrange("redisTest:myzset", 2, 3) == newRedisArray(@[
+      &&"three",
+      &&"3",
+      &&"four",
+      &&"4"
+    ])
+  # delete all keys in the DB at the end of the tests
+  discard r.flushdb()
+  discard r.quit()
+
+suite "redis streams tests":
+  syncTests()
+
+when compileOption("threads"):
+  proc threadFunc() {.thread.} =
+    suite "redis streams threaded tests":
+      syncTests()
+
+  var th: Thread[void]
+  createThread(th, threadFunc)
+  joinThread(th)
+
+

--- a/tests/teststreams.nim
+++ b/tests/teststreams.nim
@@ -8,11 +8,9 @@ const
   group = "mygroup"
   consumer = "myconsumer"
 
-proc `&`(i: SomeInteger): auto = RedisValue(kind: vkInt, i: i.int)
-proc `&`(s: string): auto = RedisValue(kind: vkStr, s: s)
-proc `&&`(s: string): auto = RedisValue(kind: vkBulkStr, bs: s)
-
-let OK = &("OK")
+proc `&`(s: string): auto = newRedisString(s)
+proc `&`(i: SomeInteger): auto = newRedisInt(i.int)
+proc `&&`(s: string): auto = newRedisBulkString(s)
 
 template syncTests() =
   let r = redisclient.open("localhost")
@@ -20,52 +18,53 @@ template syncTests() =
   #doAssert keys.len == 0, "Don't want to mess up an existing DB."
 
   test "test xack":
-    var expected = &0
+    discard r.del(@[stream])
+    var expected = 0
     # xack on a stream that doesn't exist
-    check r.xack(stream, group, "0-0") == expected
+    check r.xack(stream, group, "0-0").getInt() == expected
     let
       id1 = r.xadd(stream, @[("one", "1")])
       id2 = r.xadd(stream, "two", "2")
       id3 = r.xadd(stream, "three", "3")
     # xack on a stream that doesn't exist
-    check r.xack(stream, group, id1) == expected
-    check r.xgroupCreate(stream, group, "0") == OK
+    check r.xack(stream, group, id1.getStr()).getInt() == expected
+    check r.xgroupCreate(stream, group, "0").getStr() == "OK"
 
     discard r.xreadGroup(group, consumer, @[(stream, ">")])
     # xack returns the number of ack'd elements
-    check r.xack(stream, group, id1) == &1
-    check r.xack(stream, group, id2, id3) == &2
+    check r.xack(stream, group, id1.getStr()).getInt() == 1
+    check r.xack(stream, group, id2.getStr(), id3.getStr()).getInt() == 2
 
   test "test xadd":
-    let id1 = $r.xadd(stream, "foo", "bar")
-    assert re.match(id1, re"[0-9]+\-[0-9]+")
+    let id1 = r.xadd(stream, "foo", "bar")
+    assert re.match(id1.getStr(), re"[0-9]+\-[0-9]+")
 
     # explicit message id
     let id2 = "9999999999999999999-0"
-    check id2 == $r.xadd(stream, "foo", "bar", id=id2)
+    check id2 == r.xadd(stream, "foo", "bar", id=id2).getStr()
 
     # with maxlen, the list evicts the first message
     discard r.xadd(stream, "foo", "bar", maxlen=2)
-    check r.xlen(stream) == &2
+    check r.xlen(stream).getInt() == 2
 
   test "test xadd nomlstream":
     # nomkstream option
     discard r.flushdb()
     discard r.xadd(stream, "some", "other", nomkstream=true)
     discard r.xadd(stream, "some", "other", nomkstream=false)
-    assert r.xlen(stream) == &1
+    assert r.xlen(stream).getInt() == 1
     discard r.xadd(stream, "foo", "bar")
-    assert r.xlen(stream) == &2
+    assert r.xlen(stream).getInt() == 2
 
   test "text xadd minlen and limit":
     discard r.xadd(stream, "foo", "bar")
     discard r.xadd(stream, "foo", "bar")
     discard r.xadd(stream, "foo", "bar")
     discard r.xadd(stream, "foo", "bar")
-    check r.xadd(stream, "foo", "bar", maxlen=3, limit=2).kind == vkError
+    check r.xadd(stream, "foo", "bar", maxlen=3, limit=2).isError()
 
     # limit can not be provided without maxlen or minid
-    discard r.xadd(stream, "foo", "bar", limit=2).kind == vkError
+    discard r.xadd(stream, "foo", "bar", limit=2).isError()
 
     # maxlen with a limit
     discard r.xadd(stream, "foo", "bar", maxlen=3, approximate=true, limit=2)
@@ -73,22 +72,22 @@ template syncTests() =
     discard r.del(@[stream])
 
     # maxlen and minid can not be provided together
-    discard r.xadd(stream, "foo", "bar", maxlen=3, minid="2").kind == vkError
+    discard r.xadd(stream, "foo", "bar", maxlen=3, minid="2").isError()
 
     # minid with a limit
-    let id1 = r.xadd(stream, "foo", "bar")
+    discard r.xadd(stream, "foo", "bar")
     discard r.xadd(stream, "foo", "bar")
     discard r.xadd(stream, "foo", "bar")
     discard r.xadd(stream, "foo", "bar")
     discard r.xadd(stream, "foo", "bar", maxlen=3, approximate=true, limit=2)
 
     # pure minid
-    let id2 = $r.xadd(stream, "foo", "bar")
-    discard r.xadd(stream, "foo", "bar", minid=id2)
+    let id2 = r.xadd(stream, "foo", "bar")
+    discard r.xadd(stream, "foo", "bar", minid=id2.getStr())
 
     # minid approximate
-    let id3 = $r.xadd(stream, "foo", "bar")
-    discard r.xadd(stream, "foo", "bar", minid=id2, approximate=true)
+    discard r.xadd(stream, "foo", "bar")
+    discard r.xadd(stream, "foo", "bar", minid=id2.getStr(), approximate=true)
 
   test "test xautoclaim":
     const
@@ -100,14 +99,14 @@ template syncTests() =
     let
       id1 = r.xadd(stream, "john", "wick")
       id2 = r.xadd(stream, "johny", "deff")
-      message = r.xrange(stream, $id1, $id1)
+      message = r.xrange(stream, id1.getStr(), id1.getStr())
 
     discard r.xgroupCreate(stream, group, "0")
 
     # trying to claim a message that isn't already pending doesn't do anything
     var response = r.xautoclaim(stream, group, consumer2, minIdleTime=0)
 
-    check $response[0] == "0-0"
+    check response[0].getStr() == "0-0"
 
     # read the group as consumer1 to initially claim the messages
     discard r.xreadgroup(group, consumer1, @[(stream, ">")])
@@ -120,9 +119,9 @@ template syncTests() =
     # reclaim the messages as consumer1, but use the justid argument
     # which only returns message ids
     response = r.xautoclaim(stream, group, consumer1, minIdleTime=0, justid=true)
-    check response[1].l == @[id1, id2]
-    response = r.xautoclaim(stream, group, consumer1, minIdleTime=0, start = $id2, justid=true)
-    check response[1].l == @[id2]
+    check response[1].getItems() == @[id1, id2]
+    response = r.xautoclaim(stream, group, consumer1, minIdleTime=0, start = id2.getStr(), justid=true)
+    check response[1].getItems() == @[id2]
 
   test "test xclaim":
     const
@@ -132,24 +131,24 @@ template syncTests() =
 
     let
       id1 = r.xadd(stream, "john", "wick")
-      messages = r.xrange(stream, $id1, $id1)
+      messages = r.xrange(stream, id1.getStr(), id1.getStr())
 
     discard r.xgroupCreate(stream, group, "0")
 
     # trying to claim a message that isn't already pending doesn't do anything
-    var response = r.xclaim(stream, group, consumer2, 0, ids = @[$id1])
-    check response.l.len == 0
+    var response = r.xclaim(stream, group, consumer2, 0, ids = @[id1.getStr()])
+    check response.len == 0
 
     # read the group as consumer1 to initially claim the messages
     discard r.xreadgroup(group, consumer1, @[(stream, ">")])
 
     # claim the message as consumer2
-    response = r.xclaim(stream, group, consumer2, 0, ids = @[$id1])
+    response = r.xclaim(stream, group, consumer2, 0, ids = @[id1.getStr()])
     check response == messages
     # reclaim the message as consumer1, but use the justid argument
     # which only returns message ids
-    response = r.xclaim(stream, group, consumer1, 0, ids = @[$id1], justid=true)
-    check response.l == @[id1]
+    response = r.xclaim(stream, group, consumer1, 0, ids = @[id1.getStr()], justid=true)
+    check response.getItems() == @[id1]
 
   test "test xclaim trimmed":
     # xclaim should not raise an exception if the item is not there
@@ -165,24 +164,24 @@ template syncTests() =
     discard r.xreadgroup(group, "consumer1", @[(stream, ">")])
 
     # add a 3rd and trim the stream down to 2 items
-    let sid3 = r.xadd(stream, "item", "0", maxlen=2)
+    discard r.xadd(stream, "item", "0", maxlen=2)
 
     # xclaim them from consumer2
     # the item that is still in the stream should be returned
-    let response = r.xclaim(stream, group, "consumer2", 0, ids = @[$sid1, $sid2])
-    check response[0] == &&"\x00\x00"
+    let response = r.xclaim(stream, group, "consumer2", 0, ids = @[sid1.getStr(), sid2.getStr()])
+    check response[0].isNil
     check response[1][0] == sid2
   test "test xdel":
     # deleting from an empty stream doesn't do anything
-    check r.xdel(stream, 1) == &0
+    check r.xdel(stream, 1).getInt() == 0
     let
       m1 = r.xadd(stream, "foo", "bar")
       m2 = r.xadd(stream, "foo", "bar")
       m3 = r.xadd(stream, "foo", "bar")
 
     # xdel returns the number of deleted elements
-    check r.xdel(stream, $m1) == &1
-    check r.xdel(stream, $m2, $m3) == &2
+    check r.xdel(stream, m1.getStr()).getInt() == 1
+    check r.xdel(stream, m2.getStr(), m3.getStr()).getInt() == 2
 
   test "test xgroup create":
     # tests xgroup_create and xinfo_groups
@@ -190,8 +189,8 @@ template syncTests() =
     discard r.xadd(stream, "foo", "bar")
     # no group is setup yet, no info to obtain
     check r.xinfoGroups(stream).len == 0
-    check r.xgroupCreate(stream, group, "0") == OK
-    let expected = RedisValue(kind: vkArray, l: @[
+    check r.xgroupCreate(stream, group, "0").getStr() == "OK"
+    let expected = newRedisArray(@[
       &&"name",
       &&group,
       &&"consumers",
@@ -209,12 +208,12 @@ template syncTests() =
 
     # an error is raised if a group is created on a stream that
     # doesn't already exist
-    discard r.xgroupCreate(stream, group, "0").kind == vkError
+    check r.xgroupCreate(stream, group, "0").isError()
 
     # however, with mkstream=True, the underlying stream is created automatically
-    check r.xgroupCreate(stream, group, "0", mkstream = true) == OK
+    check r.xgroupCreate(stream, group, "0", mkstream = true).getStr() == "OK"
 
-    let expected = RedisValue(kind: vkArray, l: @[
+    let expected = newRedisArray(@[
       &&"name",
       &&group,
       &&"consumers",
@@ -230,34 +229,34 @@ template syncTests() =
     discard r.del(@[stream])
     discard r.xadd(stream, "foo", "bar")
     discard r.xadd(stream, "foo", "bar")
-    check r.xgroupCreate(stream, group, "0") == OK
-    check r.xgroupCreateConsumer(stream, group, consumer) == &1
+    check r.xgroupCreate(stream, group, "0").getStr() == "OK"
+    check r.xgroupCreateConsumer(stream, group, consumer).getInt() == 1
 
     # read all messages from the group
     discard r.xreadgroup(group, consumer, @[(stream, ">")])
 
     # deleting the consumer should return 2 pending messages
-    check r.xgroupDelConsumer(stream, group, consumer) == &2
+    check r.xgroupDelConsumer(stream, group, consumer).getInt() == 2
 
   test "test xgroup destroy":
     discard r.del(@[stream])
     discard r.xadd(stream, "foo", "bar")
 
     # destroying a nonexistent group returns False
-    check r.xgroupDestroy(stream, group) == &0
-    check r.xgroupCreate(stream, group, "0") == OK
-    check r.xgroupDestroy(stream, group) == &1
+    check r.xgroupDestroy(stream, group).getInt() == 0
+    check r.xgroupCreate(stream, group, "0").getStr() == "OK"
+    check r.xgroupDestroy(stream, group).getInt() == 1
 
   test "test xgroup setid":
     discard r.del(@[stream])
     let mid = r.xadd(stream, "foo", "bar")
 
-    check r.xgroupCreate(stream, group, "0") == OK
+    check r.xgroupCreate(stream, group, "0").getStr() == "OK"
 
     # advance the last_delivered_id to the message_id
-    check r.xgroupSetId(stream, group, $mid) == OK
+    check r.xgroupSetId(stream, group, mid.getStr()).getStr() == "OK"
 
-    let expected = RedisValue(kind: vkArray, l: @[
+    let expected = newRedisArray(@[
       &&"name",
       &&group,
       &&"consumers",
@@ -271,12 +270,11 @@ template syncTests() =
 
   test "text xinfo consumers":
     discard r.del(@[stream])
-    let
-      m1 = r.xadd(stream, "foo", "bar")
-      m2 = r.xadd(stream, "foo", "bar")
-      m3 = r.xadd(stream, "foo", "bar")
+    discard r.xadd(stream, "foo", "bar")
+    discard r.xadd(stream, "foo", "bar")
+    discard r.xadd(stream, "foo", "bar")
 
-    check r.xgroupCreate(stream, group, "0") == OK
+    check r.xgroupCreate(stream, group, "0").getStr() == "OK"
     discard r.xreadgroup(group, "consumer1", @[(stream, ">")], count=1)
     discard r.xreadgroup(group, "consumer2", @[(stream, ">")])
     let info = r.xinfoConsumers(stream, group)
@@ -286,13 +284,13 @@ template syncTests() =
     #[
     # FIXME temporary disable cuz `idle` is inconsistent
 
-    let expected = RedisValue(kind: vkArray, l: @[
-      RedisValue(kind: vkArray, l: @[
+    let expected = newRedisArray(@[
+      newRedisArray(@[
         &&"name", &&"consumer1",
         &&"pending", &1,
         &&"idle", &0,
       ]),
-      RedisValue(kind: vkArray, l: @[
+      newRedisArray(@[
         &&"name", &&"consumer2",
         &&"pending", &2,
         &&"idle", &0
@@ -303,26 +301,25 @@ template syncTests() =
 
   test "test xinfo stream":
     discard r.del(@[stream])
+    let m1 = r.xadd(stream, "foo", "bar")
+    discard r.xadd(stream, "foo", "bar")
+    let m3 = r.xadd(stream, "foo", "bar")
     let
-      m1 = r.xadd(stream, "foo", "bar")
-      m2 = r.xadd(stream, "foo", "bar")
-      m3 = r.xadd(stream, "foo", "bar")
-    let
-      expected = RedisValue(kind: vkArray, l: @[
+      expected = newRedisArray(@[
         &&"length", &3,
         &&"radix-tree-keys", &1,
         &&"radix-tree-nodes", &2,
         &&"last-generated-id", m3,
         &&"groups", &0,
-        &&"first-entry", RedisValue(kind: vkArray, l: @[
-          &&($m1),
-          RedisValue(kind: vkArray, l: @[
+        &&"first-entry", newRedisArray(@[
+          &&(m1.getStr()),
+          newRedisArray(@[
             &&"foo", &&"bar"
           ])
         ]),
-        &&"last-entry", RedisValue(kind: vkArray, l: @[
-          &&($m3),
-          RedisValue(kind: vkArray, l: @[
+        &&"last-entry", newRedisArray(@[
+          &&(m3.getStr()),
+          newRedisArray(@[
             &&"foo", &&"bar"
           ])
         ]),
@@ -331,34 +328,33 @@ template syncTests() =
 
   test "test xlen":
     discard r.del(@[stream])
-    let
-      m1 = r.xadd(stream, "foo", "bar")
-      m2 = r.xadd(stream, "foo", "bar")
-      m3 = r.xadd(stream, "foo", "bar")
-    check r.xlen(stream) == &3
+    discard r.xadd(stream, "foo", "bar")
+    discard r.xadd(stream, "foo", "bar")
+    discard r.xadd(stream, "foo", "bar")
+    check r.xlen(stream).getInt() == 3
 
   test "test xpending":
     discard r.del(@[stream])
     let
       m1 = r.xadd(stream, "foo", "bar")
       m2 = r.xadd(stream, "foo", "bar")
-      m3 = r.xadd(stream, "foo", "bar")
-    check r.xgroupCreate(stream, group, "0") == OK
-    check r.xpending(stream, group)[0] == &0
+    discard r.xadd(stream, "foo", "bar")
+    check r.xgroupCreate(stream, group, "0").getStr() == "OK"
+    check r.xpending(stream, group)[0].getInt() == 0
 
     # read 1 message from the group with each consumer
     discard r.xreadgroup(group, "consumer1", @[(stream, ">")], count=1)
     discard r.xreadgroup(group, "consumer2", @[(stream, ">")], count=1)
 
-    let expected = RedisValue(kind: vkArray, l: @[
+    let expected = newRedisArray(@[
       &2,
-      &&($m1),
-      &&($m2),
-      RedisValue(kind: vkArray, l: @[
-        RedisValue(kind: vkArray, l: @[
+      &&(m1.getStr()),
+      &&(m2.getStr()),
+      newRedisArray(@[
+        newRedisArray(@[
           &&"consumer1", &&"1"
         ]),
-        RedisValue(kind: vkArray, l: @[
+        newRedisArray(@[
           &&"consumer2", &&"1"
         ])
       ])
@@ -370,8 +366,8 @@ template syncTests() =
     let
       m1 = r.xadd(stream, "foo", "bar")
       m2 = r.xadd(stream, "foo", "bar")
-    check r.xgroupCreate(stream, group, "0") == OK
-    check r.xpending(stream, group)[0] == &0
+    check r.xgroupCreate(stream, group, "0").getStr() == "OK"
+    check r.xpending(stream, group)[0].getInt() == 0
 
     # xpending range on a group that has no consumers yet
     check r.xpending(stream, group, "-", "+", 5).len == 0
@@ -383,17 +379,16 @@ template syncTests() =
 
     let response = r.xpending(stream, group, "-", "+", 5)
     check response.len == 2
-    check $response[0][0] == $m1
-    check $response[0][1] == "consumer1"
-    check $response[1][0] == $m2
-    check $response[1][1] == "consumer2"
+    check response[0][0] == m1
+    check response[0][1].getStr() == "consumer1"
+    check response[1][0] == m2
+    check response[1][1].getStr() == "consumer2"
 
   test "test xpending range idle":
     discard r.del(@[stream])
-    let
-      m1 = r.xadd(stream, "foo", "bar")
-      m2 = r.xadd(stream, "foo", "bar")
-    check r.xgroupCreate(stream, group, "0") == OK
+    discard r.xadd(stream, "foo", "bar")
+    discard r.xadd(stream, "foo", "bar")
+    check r.xgroupCreate(stream, group, "0").getStr() == "OK"
 
     # read 1 message from the group with each consumer
     discard r.xreadgroup(group, "consumer1", @[(stream, ">")], count=1)
@@ -413,23 +408,23 @@ template syncTests() =
       m3 = r.xadd(stream, "foo", "bar")
       m4 = r.xadd(stream, "foo", "bar")
 
-    var response = r.xrange(stream, start = $m1)
-    check $response[0][0] == $m1
-    check $response[1][0] == $m2
-    check $response[2][0] == $m3
-    check $response[3][0] == $m4
+    var response = r.xrange(stream, start = m1.getStr())
+    check response[0][0] == m1
+    check response[1][0] == m2
+    check response[2][0] == m3
+    check response[3][0] == m4
 
-    response = r.xrange(stream, start = $m2, stop = $m3)
-    check $response[0][0] == $m2
-    check $response[1][0] == $m3
+    response = r.xrange(stream, start = m2.getStr(), stop = m3.getStr())
+    check response[0][0] == m2
+    check response[1][0] == m3
 
-    response = r.xrange(stream, stop = $m3)
-    check $response[0][0] == $m1
-    check $response[1][0] == $m2
-    check $response[2][0] == $m3
+    response = r.xrange(stream, stop = m3.getStr())
+    check response[0][0] == m1
+    check response[1][0] == m2
+    check response[2][0] == m3
 
-    response = r.xrange(stream, stop = $m2, count=1)
-    check $response[0][0] == $m1
+    response = r.xrange(stream, stop = m2.getStr(), count=1)
+    check response[0][0] == m1
 
   test "test xread":
     discard r.del(@[stream])
@@ -437,81 +432,81 @@ template syncTests() =
       m1 = r.xadd(stream, "foo", "bar")
       m2 = r.xadd(stream, "bing", "baz")
 
-    var expected = RedisValue(kind: vkArray, l: @[
+    var expected = newRedisArray(@[
       &&stream,
-      RedisValue(kind: vkArray, l: @[
-        r.xrange(stream, $m1, $m1)[0],
-        r.xrange(stream, $m2, $m2)[0]
+      newRedisArray(@[
+        r.xrange(stream, m1.getStr(), m1.getStr())[0],
+        r.xrange(stream, m2.getStr(), m2.getStr())[0]
       ])
     ])
     # xread starting at 0 returns both messages
     check r.xread(@[(stream, "0")])[0] == expected
 
-    expected = RedisValue(kind: vkArray, l: @[
+    expected = newRedisArray(@[
       &&stream,
-      RedisValue(kind: vkArray, l: @[
-        r.xrange(stream, $m1, $m1)[0]
+      newRedisArray(@[
+        r.xrange(stream, m1.getStr(), m1.getStr())[0]
       ])
     ])
     # xread starting at 0 and count=1 returns only the first message
     check r.xread(@[(stream, "0")], count=1)[0] == expected
 
-    expected = RedisValue(kind: vkArray, l: @[
+    expected = newRedisArray(@[
       &&stream,
-      RedisValue(kind: vkArray, l: @[
-        r.xrange(stream, $m2, $m2)[0]
+      newRedisArray(@[
+        r.xrange(stream, m2.getStr(), m2.getStr())[0]
       ])
     ])
     # xread starting at m1 returns only the second message
-    check r.xread(@[(stream, $m1)])[0] == expected
+    check r.xread(@[(stream, m1.getStr())])[0] == expected
 
     # xread starting at the last message returns an empty list
-    check r.xread(@[(stream, $m2)]).len == 0
+    check r.xread(@[(stream, m2.getStr())]).isNil
   test "test xreadgroup":
     discard r.del(@[stream])
     let
       m1 = r.xadd(stream, "foo", "bar")
       m2 = r.xadd(stream, "bing", "baz")
-    check r.xgroupCreate(stream, group, "0") == OK
+    check r.xgroupCreate(stream, group, "0").getStr() == "OK"
 
-    var expected = RedisValue(kind: vkArray, l: @[
+    var expected = newRedisArray(@[
       &&stream,
-      RedisValue(kind: vkArray, l: @[
-        r.xrange(stream, $m1, $m1)[0],
-        r.xrange(stream, $m2, $m2)[0]
+      newRedisArray(@[
+        r.xrange(stream, m1.getStr(), m1.getStr())[0],
+        r.xrange(stream, m2.getStr(), m2.getStr())[0]
       ])
     ])
     # xreadgroup starting at 0 returns both messages
     check r.xreadGroup(group, "consumer1", @[(stream, ">")])[0] == expected
 
-    check r.xgroupDestroy(stream, group) == &1
-    check r.xgroupCreate(stream, group, "0") == OK
+    check r.xgroupDestroy(stream, group).getInt() == 1
+    check r.xgroupCreate(stream, group, "0").getStr() == "OK"
 
-    expected = RedisValue(kind: vkArray, l: @[
+    expected = newRedisArray(@[
       &&stream,
-      RedisValue(kind: vkArray, l: @[
-        r.xrange(stream, $m1, $m1)[0]
+      newRedisArray(@[
+        r.xrange(stream, m1.getStr(), m1.getStr())[0]
       ])
     ])
     # xreadgroup with count=1 returns only the first message
     check r.xreadGroup(group, "consumer1", @[(stream, ">")], count=1)[0] == expected
 
-    check r.xgroupDestroy(stream, group) == &1
+    check r.xgroupDestroy(stream, group).getInt() == 1
 
     # create the group using $ as the last id meaning subsequent reads
     # will only find messages added after this
-    check r.xgroupCreate(stream, group, "$") == OK
+    check r.xgroupCreate(stream, group, "$").getStr() == "OK"
 
-    check r.xreadGroup(group, "consumer1", @[(stream, ">")]).len == 0
+    check r.xreadGroup(group, "consumer1", @[(stream, ">")]) == nil
 
     # xreadgroup with noack does not have any items in the PEL
     check r.xgroupDestroy(stream, group) == &1
-    check r.xgroupCreate(stream, group, "0") == OK
+    check r.xgroupCreate(stream, group, "0").getStr() == "OK"
 
     check r.xreadGroup(group, "consumer1", @[(stream, ">")], noack=true)[0][1].len == 2
 
     # now there should be nothing pending
-    check r.xreadGroup(group, "consumer1", @[(stream, ">")], noack=true).len == 0
+    check r.xreadGroup(group, "consumer1", @[(stream, ">")], noack=true) == nil
 
     #check r.xgroupDestroy(stream, group) == &1
     #check r.xgroupCreate(stream, group, "0") == OK
@@ -524,58 +519,56 @@ template syncTests() =
       m3 = r.xadd(stream, "foo", "bar")
       m4 = r.xadd(stream, "foo", "bar")
 
-    var response = r.xrevrange(stream, stop = $m4)
+    var response = r.xrevrange(stream, stop = m4.getStr())
 
-    check $response[0][0] == $m4
-    check $response[1][0] == $m3
-    check $response[2][0] == $m2
-    check $response[3][0] == $m1
+    check response[0][0] == m4
+    check response[1][0] == m3
+    check response[2][0] == m2
+    check response[3][0] == m1
 
-    response = r.xrevrange(stream, start = $m2, stop = $m3)
-    check $response[0][0] == $m3
-    check $response[1][0] == $m2
+    response = r.xrevrange(stream, start = m2.getStr(), stop = m3.getStr())
+    check response[0][0] == m3
+    check response[1][0] == m2
 
-    response = r.xrevrange(stream, start = $m3)
-    check $response[0][0] == $m4
-    check $response[1][0] == $m3
+    response = r.xrevrange(stream, start = m3.getStr())
+    check response[0][0] == m4
+    check response[1][0] == m3
 
-    response = r.xrevrange(stream, start = $m2, count=1)
-    check $response[0][0] == $m4
+    response = r.xrevrange(stream, start = m2.getStr(), count=1)
+    check response[0][0] == m4
 
   test "test xtrim":
     discard r.del(@[stream])
 
     # trimming an empty key doesn't do anything
-    check r.xtrim(stream, 1000) == &0
+    check r.xtrim(stream, 1000).getInt() == 0
 
-    var
-      m1 = r.xadd(stream, "foo", "bar")
-      m2 = r.xadd(stream, "foo", "bar")
-      m3 = r.xadd(stream, "foo", "bar")
-      m4 = r.xadd(stream, "foo", "bar")
+    discard r.xadd(stream, "foo", "bar")
+    discard r.xadd(stream, "foo", "bar")
+    discard r.xadd(stream, "foo", "bar")
+    discard r.xadd(stream, "foo", "bar")
 
     # trimming an amount large than the number of messages
     # doesn't do anything
-    check r.xtrim(stream, 5) == &0
+    check r.xtrim(stream, 5).getInt() == 0
 
     # 1 message is trimmed
-    check r.xtrim(stream, 3) == &1
+    check r.xtrim(stream, 3).getInt() == 1
 
   test "test xtrim minlen amdn lenght args":
     discard r.del(@[stream])
-    let
-      m1 = r.xadd(stream, "foo", "bar")
-      m2 = r.xadd(stream, "foo", "bar")
-      m3 = r.xadd(stream, "foo", "bar")
-      m4 = r.xadd(stream, "foo", "bar")
+    discard r.xadd(stream, "foo", "bar")
+    discard r.xadd(stream, "foo", "bar")
+    discard r.xadd(stream, "foo", "bar")
+    discard r.xadd(stream, "foo", "bar")
 
-    check r.xtrim(stream, 3, limit=2).kind == vkError
+    check r.xtrim(stream, 3, limit=2).isError()
 
     # maxlen with a limit
-    check r.xtrim(stream, 3, approximate=true, limit=2) == &0
+    check r.xtrim(stream, 3, approximate=true, limit=2).getInt() == 0
 
     discard r.del(@[stream])
-    check r.xtrim(stream, maxlen=3, minid="sometestvalue") == &0
+    check r.xtrim(stream, maxlen=3, minid="sometestvalue").getInt() == 0
 
   # delete all keys in the DB at the end of the tests
   discard r.flushdb()


### PR DESCRIPTION
This PR uses new redisparser, force devs to check value type when dealing w/ RedisValue 

It's a breaking change and not backward compatible.